### PR TITLE
Win32: check for IPV6_V6ONLY socket option availability at runtime

### DIFF
--- a/Csocket.cc
+++ b/Csocket.cc
@@ -1076,8 +1076,15 @@ bool Csock::Listen( u_short iPort, int iMaxConns, const CS_STRING & sBindHost, u
 		return( false );
 
 #ifdef HAVE_IPV6
-// there's no IPPROTO_IPV6 below Win XP. - KiNgMaR
-#if (!defined(_WIN32) && defined(IPV6_V6ONLY)) || (defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0501)
+#ifdef _WIN32
+# ifndef IPPROTO_IPV6
+#  define IPPROTO_IPV6 41 /* define for apps with _WIN32_WINNT < 0x0501 (XP) */
+# endif /* !IPPROTO_IPV6 */
+	/* check for IPV6_V6ONLY support at runtime */
+	OSVERSIONINFOW lvi = { sizeof(OSVERSIONINFOW), 0 };
+	if(::GetVersionExW(&lvi) && lvi.dwMajorVersion >= 6) // IPV6_V6ONLY is supported on Windows Vista or later.
+	{
+#endif /* _WIN32 */
 	if( GetIPv6() )
 	{
 		// per RFC3493#5.3
@@ -1085,7 +1092,9 @@ bool Csock::Listen( u_short iPort, int iMaxConns, const CS_STRING & sBindHost, u
 		if( setsockopt( m_iReadSock, IPPROTO_IPV6, IPV6_V6ONLY, (char *)&on, sizeof( on ) ) != 0 )
 			PERROR( "IPV6_V6ONLY" );
 	}
-#endif /* IPV6_V6ONLY */
+#ifdef _WIN32
+	}
+#endif /* _WIN32 */
 #endif /* HAVE_IPV6 */
 
 	m_address.SinFamily();


### PR DESCRIPTION
Win32: check for IPV6_V6ONLY socket option availability at runtime. This way, Server 2008/Vista users and above can use this feature even if the app has been compiled with XP (or lower) compatibility.
