### PR TITLE
Change namespace for <fcntl.h>

### DIFF
--- a/Csocket.h
+++ b/Csocket.h
@@ -45,7 +45,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/time.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/file.h>
 
 #ifndef _WIN32


### PR DESCRIPTION
- Fixes warnings under musl-libc.
- `<fcntl.h>` should be universal in the Unix world, it's more likely a system doesn't have `<sys/fcntl.h>` than if it doesn't have `<fcntl.h>` (and has `<sys/fcntl.h>`.)
