### PR TITLE
Add a getter for the ssl object.

### DIFF
--- a/Csocket.cc
+++ b/Csocket.cc
@@ -2508,6 +2508,13 @@ void Csock::SetSSLObject( SSL *ssl, bool bDeleteExisting )
 		FREE_SSL();
 	m_ssl = ssl; 
 }
+SSL * Csock::GetSSLObject() const
+{
+	if( m_ssl )
+		return( m_ssl );
+
+	return( NULL );
+}
 void Csock::SetCTXObject( SSL_CTX *sslCtx, bool bDeleteExisting ) 
 {
 	if( bDeleteExisting )

--- a/Csocket.h
+++ b/Csocket.h
@@ -876,6 +876,7 @@ public:
 	int GetSSLMethod() const;
 
 	void SetSSLObject( SSL *ssl, bool bDeleteExisting = false );
+	SSL * GetSSLObject() const;
 	void SetCTXObject( SSL_CTX *sslCtx, bool bDeleteExisting = false );
 	SSL_SESSION * GetSSLSession() const;
 


### PR DESCRIPTION
The `ssl` object is required by the libval library to perform DANE validation of the TLS certificate(s) sent by the server.

See znc/znc#854