### PR TITLE
ChatServer --pem-file option requires an argument

### DIFF
--- a/examples/ChatServer.cc
+++ b/examples/ChatServer.cc
@@ -156,11 +156,11 @@ void CTimeoutLogin::RunJob()
 
 static struct option s_apOpts[] =
 {
-	{ "port", 					1, 0, 0 },
-	{ "bind-host", 				1, 0, 0 },
-	{ "enable-ssl",				0, 0, 0 },
-	{ "pem-file",				0, 0, 0 },
-	{ "require-client-cert",	1, 0, 0 },
+	{ "port", 					required_argument,	0, 0 },
+	{ "bind-host", 				required_argument,	0, 0 },
+	{ "enable-ssl",				no_argument,		0, 0 },
+	{ "pem-file",				required_argument,	0, 0 },
+	{ "require-client-cert",	required_argument,	0, 0 },
 	{ NULL, 					0, 0, 0 }
 };
 


### PR DESCRIPTION
ChatServer was segfaulting whenever using `--pem-file` due to a getopt mistake. Fixed and switched to longform option struct syntax to avoid future errors.