### PR TITLE
Cherry-pick: Fix build with LibreSSL

### DIFF
--- a/Csocket.cc
+++ b/Csocket.cc
@@ -47,6 +47,7 @@
 #include <stdio.h>
 #include <openssl/conf.h>
 #include <openssl/engine.h>
+#include <openssl/comp.h>
 #endif /* HAVE_LIBSSL */
 
 #ifdef HAVE_ICU


### PR DESCRIPTION
LibreSSL does not include openssl/comp.h from openssl/ssl.h making build of Csocket fail. this patch fixes this error.
(cherry picked from commit 5494c125599fbe02e6d7839d1a8ebeffe3e77907)