### PR TITLE
OpenSSL 1.1 compatibility

### DIFF
--- a/Csocket.cc
+++ b/Csocket.cc
@@ -51,9 +51,15 @@
 #ifndef OPENSSL_NO_COMP
 #include <openssl/comp.h>
 #endif
+#define HAVE_ERR_REMOVE_STATE
 #ifdef OPENSSL_VERSION_NUMBER
+# if OPENSSL_VERSION_NUMBER >= 0x10000000
+#  undef HAVE_ERR_REMOVE_STATE
+#  define HAVE_ERR_REMOVE_THREAD_STATE
+#endif
 # ifndef LIBRESSL_VERSION_NUMBER /* forked from OpenSSL 1.0.1g, sets high version "with the idea of discouraging software from relying on magic numbers for detecting features"(!) */
 #  if OPENSSL_VERSION_NUMBER >= 0x10100000
+#   undef HAVE_ERR_REMOVE_THREAD_STATE /* 1.1.0-pre4: openssl/openssl@8509dcc9f319190c565ab6baad7c88d37a951d1c */
 #   undef OPENSSL_NO_SSL2              /* 1.1.0-pre4: openssl/openssl@e80381e1a3309f5d4a783bcaa508a90187a48882 */
 #   define OPENSSL_NO_SSL2             /* 1.1.0-pre1: openssl/openssl@45f55f6a5bdcec411ef08a6f8aae41d5d3d234ad */
 #   define HAVE_OPAQUE_X509            /* 1.1.0-pre1: openssl/openssl@2c81e476fab0e3e0b6140652b4577bf6f3b827be */
@@ -545,7 +551,11 @@ bool InitCsocket()
 void ShutdownCsocket()
 {
 #ifdef HAVE_LIBSSL
+#if defined( HAVE_ERR_REMOVE_THREAD_STATE )
+	ERR_remove_thread_state( NULL );
+#elif defined( HAVE_ERR_REMOVE_STATE )
 	ERR_remove_state( 0 );
+#endif
 #ifndef OPENSSL_NO_ENGINE
 	ENGINE_cleanup();
 #endif

--- a/Csocket.cc
+++ b/Csocket.cc
@@ -45,9 +45,12 @@
 
 #ifdef HAVE_LIBSSL
 #include <stdio.h>
+#include <openssl/ssl.h>
 #include <openssl/conf.h>
 #include <openssl/engine.h>
+#ifndef OPENSSL_NO_COMP
 #include <openssl/comp.h>
+#endif
 #endif /* HAVE_LIBSSL */
 
 #ifdef HAVE_ICU
@@ -531,8 +534,12 @@ void ShutdownCsocket()
 {
 #ifdef HAVE_LIBSSL
 	ERR_remove_state( 0 );
+#ifndef OPENSSL_NO_ENGINE
 	ENGINE_cleanup();
+#endif
+#ifndef OPENSSL_IS_BORINGSSL
 	CONF_modules_unload( 1 );
+#endif
 	ERR_free_strings();
 	EVP_cleanup();
 	CRYPTO_cleanup_all_ex_data();
@@ -573,6 +580,7 @@ bool InitSSL( ECompType eCompressionType )
 	}
 #endif /* _WIN32 */
 
+#ifndef OPENSSL_NO_COMP
 	COMP_METHOD *cm = NULL;
 
 	if( CT_ZLIB & eCompressionType )
@@ -588,6 +596,7 @@ bool InitSSL( ECompType eCompressionType )
 		if( cm )
 			SSL_COMP_add_compression_method( CT_RLE, cm );
 	}
+#endif
 
 	// setting this up once in the begining
 	s_iCsockSSLIdx = SSL_get_ex_new_index( 0, NULL, NULL, NULL, NULL );
@@ -1724,6 +1733,8 @@ SSL_CTX * Csock::SetupServerCTX()
 #ifndef OPENSSL_NO_ECDH
 	// Errors for the following block are non-fatal (ECDHE is nice to have
 	// but not a requirement)
+#ifndef OPENSSL_IS_BORINGSSL
+	// BoringSSL does this thing automatically
 #if defined( SSL_CTX_set_ecdh_auto )
 	// Auto-select sensible curve
 	if( !SSL_CTX_set_ecdh_auto( pCTX , 1 ) )
@@ -1742,6 +1753,7 @@ SSL_CTX * Csock::SetupServerCTX()
 		ERR_clear_error();
 	}
 #endif /* SSL_CTX_set_tmp_ecdh */
+#endif /* !OPENSSL_IS_BORINGSSL */
 #endif /* OPENSSL_NO_ECDH */
 
 	if( !ConfigureCTXOptions( pCTX ) )

--- a/Csocket.cc
+++ b/Csocket.cc
@@ -2632,11 +2632,11 @@ CS_STRING Csock::GetPeerPubKey() const
 {
 	CS_STRING sKey;
 
-	SSL_SESSION * pSession = GetSSLSession();
+	X509 * pCert = GetX509();
 
-	if( pSession && pSession->peer )
+	if( pCert )
 	{
-		EVP_PKEY * pKey = X509_get_pubkey( pSession->peer );
+		EVP_PKEY * pKey = X509_get_pubkey( pCert );
 		if( pKey )
 		{
 			char *hxKey = NULL;
@@ -2665,6 +2665,7 @@ CS_STRING Csock::GetPeerPubKey() const
 			}
 			EVP_PKEY_free( pKey );
 		}
+		X509_free( pCert );
 	}
 	return( sKey );
 }

--- a/Csocket.cc
+++ b/Csocket.cc
@@ -58,6 +58,8 @@
 #   define OPENSSL_NO_SSL2             /* 1.1.0-pre1: openssl/openssl@45f55f6a5bdcec411ef08a6f8aae41d5d3d234ad */
 #   define HAVE_OPAQUE_X509            /* 1.1.0-pre1: openssl/openssl@2c81e476fab0e3e0b6140652b4577bf6f3b827be */
 #   define HAVE_OPAQUE_EVP_PKEY        /* 1.1.0-pre3: openssl/openssl@3aeb93486588e7dd01379c50b8fd496d55cf8858 */
+#   define HAVE_OPAQUE_RSA             /* 1.1.0-pre5: openssl/openssl@9862e9aa98ee1e38fbcef8d1dd5db0e750eb5e8d */
+#   define HAVE_OPAQUE_DSA             /* 1.1.0-pre5: openssl/openssl@1258396d73cf937e4daaf2c35377011b9366f956 */
 #  endif
 # endif /* LIBRESSL_VERSION_NUMBER */
 #endif /* OPENSSL_VERSION_NUMBER */
@@ -2648,20 +2650,28 @@ CS_STRING Csock::GetPeerPubKey() const
 #endif /* HAVE_OPAQUE_EVP_PKEY */
 			switch( iType )
 			{
+#ifndef OPENSSL_NO_RSA
 			case EVP_PKEY_RSA:
-#ifdef HAVE_OPAQUE_EVP_PKEY
+# ifdef HAVE_OPAQUE_RSA
+				RSA_get0_key( EVP_PKEY_get0_RSA( pKey ), &pPubKey, NULL, NULL );
+# elif defined( HAVE_OPAQUE_EVP_PKEY )
 				pPubKey = EVP_PKEY_get0_RSA( pKey )->n;
-#else
+# else
 				pPubKey = pKey->pkey.rsa->n;
-#endif /* HAVE_OPAQUE_EVP_PKEY */
+# endif /* HAVE_OPAQUE_RSA */
 				break;
+#endif /* OPENSSL_NO_RSA */
+#ifndef OPENSSL_NO_DSA
 			case EVP_PKEY_DSA:
-#ifdef HAVE_OPAQUE_EVP_PKEY
+# ifdef HAVE_OPAQUE_DSA
+				DSA_get0_key( EVP_PKEY_get0_DSA( pKey ), &pPubKey, NULL );
+# elif defined( HAVE_OPAQUE_EVP_PKEY )
 				pPubKey = EVP_PKEY_get0_DSA( pKey )->pub_key;
-#else
+# else
 				pPubKey = pKey->pkey.dsa->pub_key;
-#endif /* HAVE_OPAQUE_EVP_PKEY */
+# endif /* HAVE_OPAQUE_DSA */
 				break;
+#endif /* OPENSSL_NO_DSA */
 			default:
 				CS_DEBUG( "Not Prepared for Public Key Type [" << iType << "]" );
 				break;

--- a/Csocket.cc
+++ b/Csocket.cc
@@ -51,6 +51,14 @@
 #ifndef OPENSSL_NO_COMP
 #include <openssl/comp.h>
 #endif
+#ifdef OPENSSL_VERSION_NUMBER
+# ifndef LIBRESSL_VERSION_NUMBER /* forked from OpenSSL 1.0.1g, sets high version "with the idea of discouraging software from relying on magic numbers for detecting features"(!) */
+#  if OPENSSL_VERSION_NUMBER >= 0x10100000
+#   undef OPENSSL_NO_SSL2              /* 1.1.0-pre4: openssl/openssl@e80381e1a3309f5d4a783bcaa508a90187a48882 */
+#   define OPENSSL_NO_SSL2             /* 1.1.0-pre1: openssl/openssl@45f55f6a5bdcec411ef08a6f8aae41d5d3d234ad */
+#  endif
+# endif /* LIBRESSL_VERSION_NUMBER */
+#endif /* OPENSSL_VERSION_NUMBER */
 #endif /* HAVE_LIBSSL */
 
 #ifdef HAVE_ICU


### PR DESCRIPTION
Hi, please find here the changes necessary to compile Csocket against OpenSSL 1.1 without errors or deprecation warnings. I've also successfully compiled against 1.0.2h and 0.9.8g, all on Debian, as part of my solution to znc/znc#1310. I have not yet exercised any of the changed code in a running application.

The commits are currently fairly granular in order to solicit feedback, however if desired I can squash and force push after addressing any comments. I'm not very experienced with C++ so please do let me know if I've made a glaring mistake or there's a better convention for something I've done, etc.
