### PR TITLE
Add basic support for UNIX sockets

### DIFF
--- a/Csocket.h
+++ b/Csocket.h
@@ -151,9 +151,18 @@ typedef ssize_t cs_ssize_t;
 #define CS_INVALID_SOCK	-1
 #endif /* _WIN32 */
 
+/* Assume that everything but windows has Unix sockets */
+#ifndef _WIN32
+#define HAVE_UNIX_SOCKET
+#endif
+
 #ifdef CSOCK_USE_POLL
 #include <poll.h>
 #endif /* CSOCK_USE_POLL */
+
+#ifdef HAVE_UNIX_SOCKET
+#include <sys/un.h>
+#endif
 
 #ifndef _NO_CSOCKET_NS // some people may not want to use a namespace
 namespace Csocket
@@ -652,6 +661,22 @@ public:
 	 * @return true on success
 	 */
 	virtual bool Connect();
+
+#ifdef HAVE_UNIX_SOCKET
+	/**
+	 * @brief Connect to a UNIX socket.
+	 * @param sPath the path to the UNIX socket.
+	 */
+	virtual bool ConnectUnix( const CS_STRING & sPath );
+
+	/**
+	 * @brief Listens for connections on an UNIX socket
+	 * @param sBindFile the socket on which to listen
+	 * @param iMaxConns the maximum amount of pending connections to allow
+	 * @param iTimeout if no connections come in by this timeout, the listener is closed
+	 */
+	virtual bool ListenUnix( const CS_STRING & sBindFile, int iMaxConns = SOMAXCONN, uint32_t iTimeout = 0 );
+#endif
 
 	/**
 	 * @brief Listens for connections
@@ -1206,7 +1231,7 @@ private:
 #endif /* HAVE_LIBSSL */
 
 	//! Create the socket
-	cs_sock_t CreateSocket( bool bListen = false );
+	cs_sock_t CreateSocket( bool bListen = false, bool bUnix = false );
 	void Init( const CS_STRING & sHostname, uint16_t uPort, int iTimeout = 60 );
 
 	// Connection State Info

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,7 +5,7 @@ SRCS=$(wildcard ../*.cc *.cc)
 VPATH=..:.
 #CXXFLAGS=-ggdb -Werror -Wall -Wextra -Wconversion -Wno-unused-parameter -Woverloaded-virtual -Wshadow -D_GNU_SOURCE -DHAVE_LIBSSL -DHAVE_IPV6 -DHAVE_C_ARES -D__DEBUG__
 CXXFLAGS=-pthread -ggdb -Werror -Wall -Wextra -Wconversion -Wno-unused-parameter -Woverloaded-virtual -Wshadow -D_GNU_SOURCE -DHAVE_LIBSSL -DHAVE_IPV6 -D__DEBUG__
-TESTBINS=GetWebPage SendTest ReceiveTest
+TESTBINS=GetWebPage SendTest ReceiveTest UnixSocket
 
 INCLUDES=-I.. -I.
 LIBS=-lssl -lcrypto -lcares -lcurl -ldl

--- a/examples/UnixSocket.cc
+++ b/examples/UnixSocket.cc
@@ -1,0 +1,94 @@
+#include <Csocket.h>
+
+#ifdef HAVE_UNIX_SOCKET
+
+static bool done = false;
+
+class CEchoServer : public Csock
+{
+public:
+	virtual void ReadData( const char * data, size_t len )
+	{
+		cout << "Echoing: ";
+		cout.write( data, len );
+		Write( data, len );
+	}
+
+	virtual void Disconnected( )
+	{
+		cout << "Client disconnected" << endl;
+		done = true;
+	}
+};
+
+class CEchoListener : public Csock
+{
+public:
+	virtual void SockError( int iErrno, const CS_STRING & sDescription )
+	{
+		cerr << "Listener error: " << sDescription << endl;
+	}
+
+	virtual Csock *GetSockObj( const CS_STRING & sHostname, uint16_t iPort )
+	{
+		cout << "Incoming connection from " << sHostname << " on port " << iPort << endl;
+		Close();
+		return new CEchoServer();
+	}
+};
+
+class CEchoClient : public Csock
+{
+public:
+	virtual void Connected()
+	{
+		EnableReadLine();
+		Write("Hello World!\n");
+	}
+
+	virtual void ReadLine( const CS_STRING & sLine )
+	{
+		if (sLine != "Hello World!\n")
+			cerr << "Did not receive expected line: " << sLine << endl;
+		Close();
+	}
+};
+
+int main( int argc, char **argv )
+{
+	CS_STRING sPath = "echo";
+
+	InitCsocket();
+	TSocketManager< Csock > cManager;
+
+	Csock *sock = new CEchoListener();
+	if (!sock->ListenUnix(sPath))
+	{
+		cerr << "Failed to listen on '" << sPath << "'!" << endl;
+		return 1;
+	}
+	cManager.AddSock(sock, "echo-listener");
+
+	sock = new CEchoClient();
+	if (!sock->ConnectUnix(sPath))
+	{
+		cerr << "Failed to connect to '" << sPath << "'!" << endl;
+		return 1;
+	}
+	cManager.AddSock(sock, "echo-client");
+	while( !done )
+		cManager.Loop();
+
+	ShutdownCsocket();
+	return( 0 );
+}
+
+#else
+
+int main( int argc, char **argv )
+{
+	cerr << "This program needs support for UNIX sockets" << endl;
+	return 1;
+}
+
+#endif


### PR DESCRIPTION
This adds some basic support for listening on and connecting to UNIX
sockets. Since a lot of code assumes, for example, that an IP address
and a port number is present, this socket will behave weirdly in various
situations, for example when listing all sockets and their remote
address. However, transferring data does work.

This also adds a simple test program to demonstrate this new support.
This program is an echo server and client in one process. It listens on
a UNIX socket, connects to it and sends the string "Hello World!" back
and forth. When run, the output is:

    Incoming connection from localhost on port 0
    Echoing: Hello World!
    Client disconnected

We can already see in this output that the remote address is not
identified correctly.

Since this program leaves the socket behind (does not delete the
socket), running the sample program again results in:

    Listener error: Address already in use
    Failed to listen on 'echo'!

Addresses: https://github.com/jimloco/Csocket/issues/68
Signed-off-by: Uli Schlachter <psychon@znc.in>