### PR TITLE
Some encoding-related changes

### DIFF
--- a/Csocket.cc
+++ b/Csocket.cc
@@ -4229,6 +4229,7 @@ void CSocketManager::Select( std::map<Csock *, EMessages> & mpeSocks )
 						// set the name of the listener
 						NewpcSock->SetParentSockName( pcSock->GetSockName() );
 						NewpcSock->SetRate( pcSock->GetRateBytes(), pcSock->GetRateTime() );
+						NewpcSock->SetEncoding( pcSock->GetEncoding() );
 						if( NewpcSock->GetSockName().empty() )
 						{
 							std::stringstream s;

--- a/Csocket.h
+++ b/Csocket.h
@@ -1254,7 +1254,6 @@ private:
 
 #ifdef HAVE_ICU
 	UConverter* m_cnvInt;
-	UConverter* m_cnvIntStrict;
 	UConverter* m_cnvExt;
 	bool m_cnvTryUTF8;
 	bool m_cnvSendUTF8;


### PR DESCRIPTION
The second patch is the result of https://github.com/znc/znc/issues/1459. It does not fix the buffer overflow (that's a bug in ICU), but uses a less weird approach for checking if a given string is valid UTF-8.

The first patch is just something that I stumbled upon while testing this. I modified `UnixSocket.cpp` to set encoding `^Latin-1` and had some problems with this at first.